### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "colors",
     "terminator"
   ],
+  "repository" : {
+    "type" : "git",
+    "url" : "git@github.com:jxnblk/hyperterminator.git"
+  },
   "author": "Brent Jackson",
   "license": "MIT"
 }


### PR DESCRIPTION
The repository field is used by the `npm repo` command. This makes it super easy for end users (like me) to view the source of the project.
